### PR TITLE
change unit of ScreenSize in example events.json

### DIFF
--- a/src/modality-specific-files/eye-tracking.md
+++ b/src/modality-specific-files/eye-tracking.md
@@ -181,7 +181,7 @@ Content of `sub-01_task-VisualSearch_events.json`:
        "ScreenDistance": 60,
        "ScreenRefreshRate": 60,
        "ScreenResolution": [1024, 768],
-       "ScreenSize": [38.6, 29]
+       "ScreenSize": [0.386, 0.29]
    }
 }
 ```


### PR DESCRIPTION
example "Content of sub-01_task-visualSearch_eyetrack.json:" had ScreenSize in cm, changed it to meters according to spec